### PR TITLE
Update code block for rbenv-doctor script

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,11 @@ If you're on macOS, we recommend installing rbenv with
 
     ~~~ sh
     $ curl -fsSL https://github.com/rbenv/rbenv-installer/raw/main/bin/rbenv-doctor | bash
+    ~~~
+
+    If successful, you should see a similar image:
+
+    ~~~ sh
     Checking for `rbenv' in PATH: /usr/local/bin/rbenv
     Checking for rbenv shims in PATH: OK
     Checking `rbenv install' support: /usr/local/bin/rbenv-install (ruby-build 20170523)


### PR DESCRIPTION
## Description
This change updates the readme to add clarity for users attempting to run the rbenv-doctor script in the Installation instructions. Currently, the script and expected output are combined in a single code-block as pictured:

![image](https://user-images.githubusercontent.com/68248886/137566825-706684e6-79fa-4ca0-8a94-e94714e1447d.png)

GitHub provides functionality to copy code from a code block. Thus, when a user clicks the copy-icon in the code block to quickly copy the script, the user copies both the script and expected output. Since the output message contains inconsistencies with its quotes (using both traditional quotes and back-ticks), the copied text has an open back-tick. Ultimately, the script will not successfully run. 

This quick change separates the rbenv-doctor script from the expected output into distinct code-blocks. This provides greater clarity in the instructions and expectations in addition to allowing users to quickly and conveniently copy the script for use.
